### PR TITLE
Fix too fast closing of header links dropdown

### DIFF
--- a/src/layouts/Layout/components/Header/Header.tsx
+++ b/src/layouts/Layout/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { useState, MouseEvent } from 'react';
+import { useState, MouseEvent, useEffect } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';
 import { useSelector } from 'react-redux';
@@ -63,15 +63,22 @@ export const Header = (props: HeaderPropsType) => {
     );
   };
 
-  const onApplicationsClose = () => {
-    setApplicationsActive(false);
-    onExpand(false);
-  };
-
   const onMenuClose = () => {
     setMenuActive(false);
     onExpand(false);
   };
+
+  useEffect(() => {
+    const onClickOutsideApplications = () => {
+      setApplicationsActive(false);
+      onExpand(false);
+    };
+
+    window.addEventListener('pointerdown', onClickOutsideApplications);
+
+    return () =>
+      window.removeEventListener('pointerdown', onClickOutsideApplications);
+  }, [onExpand]);
 
   return (
     <header className='header'>
@@ -97,9 +104,8 @@ export const Header = (props: HeaderPropsType) => {
       </div>
 
       <div
-        tabIndex={0}
         onClick={onApplicationsToggle}
-        onBlur={() => setTimeout(onApplicationsClose, 100)}
+        onPointerDown={(e) => e.stopPropagation()}
         className={classNames('matrix', {
           active: applicationsActive
         })}
@@ -109,6 +115,7 @@ export const Header = (props: HeaderPropsType) => {
       </div>
 
       <div
+        onPointerDown={(e) => e.stopPropagation()}
         className={classNames('applicationswrapper', {
           active: applicationsActive
         })}


### PR DESCRIPTION
## Reasoning

- dropdown menu with additional links in header closed 100ms after the opener button lost focus
- this made clicking on the links ineffective if user held down mouse button a little longer and it seems like the links don't work

## Proposed Changes

- instead of closing the dropdown menu after opener button loses focus, listen to pointerup event on window
- pointerup events triggered on the opener button and dropdown menu itself prevent event propagation to the window to stop the action

