### PR TITLE
Analytics Charts Updates

### DIFF
--- a/src/components/Chart/ChartComposed.tsx
+++ b/src/components/Chart/ChartComposed.tsx
@@ -29,7 +29,9 @@ export const ChartComposed = ({
   stacked,
   stackedLabel,
   showLegend = true,
-  customDomain = false
+  customDomain = false,
+  tickCountY = 10,
+  height = 320
 }: ChartComposedProps) => {
   const [hoveredSeries, setHoveredSeries] = useState<string>();
   const [hiddenSeries, setHiddenSeries] =
@@ -59,7 +61,11 @@ export const ChartComposed = ({
   };
 
   const getSeriesOpacity = (series: ChartConfigType) => {
-    return hoveredSeries === series.label ? 0.3 : 1;
+    if (!hoveredSeries) {
+      return 1;
+    }
+
+    return hoveredSeries === series.label ? 1 : 0.3;
   };
 
   const getLegendPayload = () => {
@@ -140,14 +146,13 @@ export const ChartComposed = ({
   };
 
   const calculateDomain = ([alpha, beta]: number[]): [number, number] => {
-    const start = alpha - alpha / 90;
     const end = beta + beta / 90;
 
     if (!isFinite(alpha) && !isFinite(beta)) {
       return [0, 0];
     }
 
-    return [start, end];
+    return [0, end];
   };
 
   return (
@@ -156,7 +161,7 @@ export const ChartComposed = ({
         hasOnlyStartEndTick ? 'has-only-start-end-tick' : ''
       }`}
     >
-      <ResponsiveContainer width='100%' height={448}>
+      <ResponsiveContainer width='100%' height={height}>
         <ComposedChart data={chartData}>
           <defs>
             <linearGradient id='transparent' x1='0' y1='0' x2='0' y2='1'>
@@ -220,7 +225,7 @@ export const ChartComposed = ({
                 stroke={sc.stroke}
                 dy={2}
                 domain={customDomain ? calculateDomain : [0, 'dataMax']}
-                tickCount={customDomain ? undefined : 10}
+                tickCount={tickCountY}
               />
               <Area
                 type='monotone'

--- a/src/components/Chart/helpers/types.ts
+++ b/src/components/Chart/helpers/types.ts
@@ -126,6 +126,8 @@ export interface StackedChartConfig {
   stacked?: boolean;
   stackedLabel?: string;
   customDomain?: boolean;
+  tickCountY?: number;
+  height?: number;
 }
 
 export interface ChartComposedConfigType {

--- a/src/pages/Analytics/Analytics.tsx
+++ b/src/pages/Analytics/Analytics.tsx
@@ -245,6 +245,8 @@ export const Analytics = () => {
                 title={'Total Accounts'}
                 series={usersChart}
                 customDomain={true}
+                tickCountY={6}
+                height={420}
               />
             </div>
           </ChartWrapper>
@@ -266,6 +268,7 @@ export const Analytics = () => {
                     </Overlay>
                   </div>
                 }
+                height={420}
               />
             </div>
           </ChartWrapper>
@@ -281,6 +284,7 @@ export const Analytics = () => {
               <AnalyticsChart
                 title={'New Applications Deployed'}
                 series={newStuffCreatedChart}
+                height={420}
               />
             </div>
           </ChartWrapper>
@@ -290,6 +294,7 @@ export const Analytics = () => {
                 title={'Staking Metrics'}
                 series={stakingMetricsChart}
                 customDomain={true}
+                tickCountY={6}
               />
             </div>
           </ChartWrapper>
@@ -299,12 +304,17 @@ export const Analytics = () => {
                 title={'Users Staking'}
                 series={usersStakingChart}
                 customDomain={true}
+                tickCountY={6}
               />
             </div>
           </ChartWrapper>
           <ChartWrapper size='half'>
             <div className='px-3 pb-3'>
-              <AnalyticsChart title='APR Metrics' series={aprsChart} />
+              <AnalyticsChart
+                title='APR Metrics'
+                series={aprsChart}
+                height={360}
+              />
             </div>
           </ChartWrapper>
           <ChartWrapper size='half'>
@@ -312,6 +322,7 @@ export const Analytics = () => {
               <AnalyticsChart
                 title={'Fees Metrics'}
                 series={networkAndDeveloperFeesChart}
+                height={360}
               />
             </div>
           </ChartWrapper>

--- a/src/pages/AnalyticsCompare/AnalyticsChart/AnalyticsChart.tsx
+++ b/src/pages/AnalyticsCompare/AnalyticsChart/AnalyticsChart.tsx
@@ -21,17 +21,15 @@ export interface AnalyticsChartDataType {
   timestamp: number;
 }
 
-export const AnalyticsChart = ({
-  series,
-  title,
-  stacked,
-  stackedLabel,
-  customDomain
-}: {
-  series: ChartListType[];
-  title?: React.ReactNode;
-} & StackedChartConfig) => {
+export const AnalyticsChart = (
+  props: {
+    series: ChartListType[];
+    title?: React.ReactNode;
+  } & StackedChartConfig
+) => {
   const ref = useRef(null);
+
+  const { series, title } = props;
 
   const { id: activeNetworkId } = useSelector(activeNetworkSelector);
   const [range, setRange] = useState<ChartResolutionRangeType>('month');
@@ -160,14 +158,12 @@ export const AnalyticsChart = ({
         {dataReady === true &&
           seriesConfig?.every((x) => x.data?.length > 0) && (
             <Chart.Composed
+              {...props}
               seriesConfig={seriesConfig}
               tooltip={{
                 dateFormat: 'dd, MMM D YYYY'
               }}
               showLegend={true}
-              stacked={stacked}
-              stackedLabel={stackedLabel}
-              customDomain={customDomain}
             />
           )}
       </div>

--- a/src/pages/AnalyticsCompare/AnalyticsChart/AnalyticsStackedChart.tsx
+++ b/src/pages/AnalyticsCompare/AnalyticsChart/AnalyticsStackedChart.tsx
@@ -183,6 +183,7 @@ export const AnalyticsStackedChart = ({
                 dateFormat: 'dd, MMM D YYYY'
               }}
               showLegend={true}
+              height={460}
             ></Chart.Composed>
           )}
         </div>

--- a/src/pages/AnalyticsCompare/AnalyticsCompare.tsx
+++ b/src/pages/AnalyticsCompare/AnalyticsCompare.tsx
@@ -155,12 +155,10 @@ export const AnalyticsCompare = () => {
               })}
             </div>
 
-            <div className='row pb-5'>
-              <AnalyticsStackedChart
-                firstSeries={selectedPills[0]}
-                secondSeries={selectedPills[1]}
-              />
-            </div>
+            <AnalyticsStackedChart
+              firstSeries={selectedPills[0]}
+              secondSeries={selectedPills[1]}
+            />
           </div>
           <div className='card-footer'></div>
         </div>


### PR DESCRIPTION
## Proposed Changes

- customDomain starts from 0 to avoid displaying dramatic drops on large contexts
- different chart heights based on data shown in order to keep a better display ratio
- reversed chart seris highlight logic: highlighted one remains fully visible, other series get a 0.3 opacity