### PR TITLE
Low Liquidity Display

### DIFF
--- a/src/appConstants/index.ts
+++ b/src/appConstants/index.ts
@@ -11,6 +11,7 @@ export const MAX_DISPLAY_TX_DATA_LENGTH = 1_000_000;
 export const MAX_DECODE_TX_DATA_LENGTH = 60_000;
 export const MAX_DISPLAY_ZERO_DECIMALS = 4;
 export const MAX_ACOUNT_TOKENS_BALANCE = 1000;
+export const LOW_LIQUIDITY_DISPLAY_TRESHOLD = 1_000_000;
 
 export const LEGACY_DELEGATION_NODES_IDENTITY = 'multiversx';
 export const HEROTAG_SUFFIX = '.elrond';

--- a/src/layouts/AccountLayout/AccountDetailsCard/components/AccountUsdValueCardItem.tsx
+++ b/src/layouts/AccountLayout/AccountDetailsCard/components/AccountUsdValueCardItem.tsx
@@ -43,9 +43,9 @@ export const AccountUsdValueCardItem = ({
 
   return (
     <CardItem className={cardItemClass} title='Value' icon={faDollarSign}>
-      <div className='d-flex align-items-center'>
+      <div className='d-flex align-items-center text-truncate gap-2'>
         {(balance || tokenBalance) && stakingDataReady && isEconomicsFetched ? (
-          <span className='me-2'>
+          <span className='text-truncate'>
             <FormatUSD
               amount={totalUsdValue.toString()}
               usd={1}


### PR DESCRIPTION
## Reasoning

- show the Low Liquidity Tooltip on Account Tokens too
- don't show the usd value is the token has a Low Liquidity and the value is over the 1mil treshold

