### PR TITLE
Deploy devnet from development branch

### DIFF
--- a/.github/workflows/deploy-devnet.yml
+++ b/.github/workflows/deploy-devnet.yml
@@ -2,7 +2,7 @@ name: deploy-devnet
 
 on:
   push:
-    branches: [main]
+    branches: [development]
   repository_dispatch:
     types: deploy-devnet
   workflow_dispatch:
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: main
+          ref: development
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
## Reasoning

- Deploy `devnet` from `development` branch ( includes Staking V4 changes )
