### PR TITLE
Next

### DIFF
--- a/src/hooks/adapter/adapter.ts
+++ b/src/hooks/adapter/adapter.ts
@@ -622,6 +622,29 @@ export const useAdapter = () => {
         })
       }),
 
+    getCollectionTransfers: ({
+      identifier,
+      ...rest
+    }: GetTransactionsType & { identifier: string }) =>
+      provider({
+        url: `/collections/${identifier}/transfers`,
+        params: getTransactionsParams({
+          ...rest
+        })
+      }),
+
+    getCollectionTransfersCount: ({
+      identifier,
+      ...rest
+    }: GetTransactionsType & { identifier: string }) =>
+      provider({
+        url: `/collections/${identifier}/transfers/count`,
+        params: getTransactionsParams({
+          isCount: true,
+          ...rest
+        })
+      }),
+
     // Nfts
 
     getNft: (identifier: string) => provider({ url: `/nfts/${identifier}` }),
@@ -673,6 +696,29 @@ export const useAdapter = () => {
     }: GetTransactionsType & { identifier: string }) =>
       provider({
         url: `/nfts/${identifier}/transactions/count`,
+        params: getTransactionsParams({
+          isCount: true,
+          ...rest
+        })
+      }),
+
+    getNftTransfers: ({
+      identifier,
+      ...rest
+    }: GetTransactionsType & { identifier: string }) =>
+      provider({
+        url: `/nfts/${identifier}/transfers`,
+        params: getTransactionsParams({
+          ...rest
+        })
+      }),
+
+    getNftTransfersCount: ({
+      identifier,
+      ...rest
+    }: GetTransactionsType & { identifier: string }) =>
+      provider({
+        url: `/nfts/${identifier}/transfers/count`,
         params: getTransactionsParams({
           isCount: true,
           ...rest

--- a/src/layouts/CollectionLayout/CollectionLayout.tsx
+++ b/src/layouts/CollectionLayout/CollectionLayout.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { useSearchParams, useParams, Outlet } from 'react-router-dom';
+import { useParams, Outlet } from 'react-router-dom';
 
 import { Loader } from 'components';
 import { useAdapter, useGetPage } from 'hooks';
@@ -12,12 +12,10 @@ import { FailedCollectionDetails } from './FailedCollectionDetails';
 
 export const CollectionLayout = () => {
   const ref = useRef(null);
-  const { firstPageRefreshTrigger } = useGetPage();
-  const [searchParams] = useSearchParams();
-  const { id: activeNetworkId } = useSelector(activeNetworkSelector);
   const dispatch = useDispatch();
+  const { firstPageRefreshTrigger } = useGetPage();
+  const { id: activeNetworkId } = useSelector(activeNetworkSelector);
   const { getCollection } = useAdapter();
-
   const { hash: collection } = useParams();
 
   const [dataReady, setDataReady] = useState<boolean | undefined>();
@@ -41,11 +39,7 @@ export const CollectionLayout = () => {
 
   useEffect(() => {
     fetchCollectionDetails();
-  }, [firstPageRefreshTrigger, activeNetworkId, collection, searchParams]);
-
-  useEffect(() => {
-    setDataReady(undefined);
-  }, [collection, activeNetworkId, searchParams]);
+  }, [firstPageRefreshTrigger, activeNetworkId, collection]);
 
   const loading = dataReady === undefined;
   const failed = dataReady === false;

--- a/src/layouts/NftLayout/NftLayout.tsx
+++ b/src/layouts/NftLayout/NftLayout.tsx
@@ -12,13 +12,10 @@ import { NftDetailsCard } from './NftDetailsCard';
 
 export const NftLayout = () => {
   const ref = useRef(null);
-  const { firstPageRefreshTrigger } = useGetPage();
-
-  const { id: activeNetworkId } = useSelector(activeNetworkSelector);
-
   const dispatch = useDispatch();
+  const { firstPageRefreshTrigger } = useGetPage();
+  const { id: activeNetworkId } = useSelector(activeNetworkSelector);
   const { getNft } = useAdapter();
-
   const { hash: identifier } = useParams();
 
   const [dataReady, setDataReady] = useState<boolean | undefined>();
@@ -51,7 +48,6 @@ export const NftLayout = () => {
     <>
       {loading && <Loader />}
       {!loading && failed && <FailedNftDetails identifier={identifier} />}
-
       <div ref={ref}>
         {!loading && !failed && (
           <div className='container page-content'>

--- a/src/layouts/TokenLayout/TokenLayout.tsx
+++ b/src/layouts/TokenLayout/TokenLayout.tsx
@@ -12,13 +12,10 @@ import { TokenDetailsCard } from './TokenDetailsCard';
 
 export const TokenLayout = () => {
   const ref = useRef(null);
-  const { firstPageRefreshTrigger } = useGetPage();
-
-  const { id: activeNetworkId } = useSelector(activeNetworkSelector);
-
   const dispatch = useDispatch();
+  const { firstPageRefreshTrigger } = useGetPage();
+  const { id: activeNetworkId } = useSelector(activeNetworkSelector);
   const { getToken } = useAdapter();
-
   const { hash: tokenId } = useParams();
 
   const [dataReady, setDataReady] = useState<boolean | undefined>();

--- a/src/layouts/TokenLayout/TokenTabs.tsx
+++ b/src/layouts/TokenLayout/TokenTabs.tsx
@@ -19,7 +19,7 @@ export const TokenTabs = () => {
       activationRoutes: [tokensRoutes.tokenDetails]
     },
     {
-      tabLabel: 'Accounts',
+      tabLabel: 'Holders',
       tabTo: urlBuilder.tokenDetailsAccounts(identifier),
       activationRoutes: [tokensRoutes.tokenDetailsAccounts]
     },

--- a/src/pages/CollectionDetails/CollectionTransactions.tsx
+++ b/src/pages/CollectionDetails/CollectionTransactions.tsx
@@ -13,8 +13,7 @@ export const CollectionTransactions = () => {
   const [searchParams] = useSearchParams();
   const { id: activeNetworkId } = useSelector(activeNetworkSelector);
 
-  const { getCollectionTransactions, getCollectionTransactionsCount } =
-    useAdapter();
+  const { getCollectionTransfers, getCollectionTransfersCount } = useAdapter();
   const { hash: identifier } = useParams();
 
   const {
@@ -24,8 +23,8 @@ export const CollectionTransactions = () => {
     isDataReady,
     dataChanged
   } = useFetchTransactions(
-    getCollectionTransactions,
-    getCollectionTransactionsCount,
+    getCollectionTransfers,
+    getCollectionTransfersCount,
     {
       identifier
     }

--- a/src/pages/NftDetails/NftDetails.tsx
+++ b/src/pages/NftDetails/NftDetails.tsx
@@ -3,12 +3,14 @@ import { Navigate } from 'react-router-dom';
 
 import { CardItem, Loader } from 'components';
 import { urlBuilder } from 'helpers';
+import { useNetworkRoute } from 'hooks';
 import { faTrophy } from 'icons/regular';
 import { NftTabs } from 'layouts/NftLayout/NftTabs';
 import { nftSelector } from 'redux/selectors';
 import { NftTypeEnum } from 'types';
 
 export const NftDetails = () => {
+  const networkRoute = useNetworkRoute();
   const { nftState } = useSelector(nftSelector);
   const { type, rarities, tags, metadata, identifier } = nftState;
 
@@ -20,7 +22,10 @@ export const NftDetails = () => {
 
   if (!showOverview) {
     return (
-      <Navigate replace to={urlBuilder.nftDetailsTransactions(identifier)} />
+      <Navigate
+        replace
+        to={networkRoute(urlBuilder.nftDetailsTransactions(identifier))}
+      />
     );
   }
 

--- a/src/pages/NftDetails/NftTransactions.tsx
+++ b/src/pages/NftDetails/NftTransactions.tsx
@@ -13,7 +13,7 @@ export const NftTransactions = () => {
   const [searchParams] = useSearchParams();
   const { id: activeNetworkId } = useSelector(activeNetworkSelector);
 
-  const { getNftTransactions, getNftTransactionsCount } = useAdapter();
+  const { getNftTransfers, getNftTransfersCount } = useAdapter();
   const { hash: identifier } = useParams();
 
   const {
@@ -22,7 +22,7 @@ export const NftTransactions = () => {
     totalTransactions,
     isDataReady,
     dataChanged
-  } = useFetchTransactions(getNftTransactions, getNftTransactionsCount, {
+  } = useFetchTransactions(getNftTransfers, getNftTransfersCount, {
     identifier
   });
 


### PR DESCRIPTION
## Proposed Changes

- Use the '/collections/${identifier}/transfers' endpoint for collection Transactions
- Use the '/nfts/${identifier}/transfers' endpoint for NFT Transactions
- Rename 'Accounts' tab from token details into 'Holders'
- Avoid rerendering the whole page on transaction page change
