### PR TITLE
Account Staking Display: Step 1

### DIFF
--- a/src/components/FormatValue/FormatUSD/FormatUSD.tsx
+++ b/src/components/FormatValue/FormatUSD/FormatUSD.tsx
@@ -26,7 +26,6 @@ export const FormatUSD = (props: FormatUSDUIType) => {
     showPrefix = true,
     className
   } = props;
-
   const amount = decimals
     ? formatAmount({
         input: String(unprocessedValue),

--- a/src/helpers/formatValue/formatAmount.ts
+++ b/src/helpers/formatValue/formatAmount.ts
@@ -1,6 +1,6 @@
 import { FormatAmountType as SdkDappFormatAmountType } from '@multiversx/sdk-dapp/utils/operations/formatAmount';
 import { stringIsInteger } from '@multiversx/sdk-dapp/utils/validation/stringIsInteger';
-import { MAX_DISPLAY_ZERO_DECIMALS, ZERO } from 'appConstants';
+import { ELLIPSIS, MAX_DISPLAY_ZERO_DECIMALS, ZERO } from 'appConstants';
 import { DECIMALS, DIGITS } from 'config';
 
 interface FormatAmountType extends SdkDappFormatAmountType {
@@ -16,7 +16,8 @@ export function formatAmount({
   addCommas = false
 }: FormatAmountType) {
   if (!stringIsInteger(input, false)) {
-    throw new Error('Invalid input');
+    console.error('Invalid input', input);
+    return ELLIPSIS;
   }
 
   showLastNonZeroDecimal =

--- a/src/helpers/getValue/getAccountDelegationDetails.ts
+++ b/src/helpers/getValue/getAccountDelegationDetails.ts
@@ -1,0 +1,53 @@
+import BigNumber from 'bignumber.js';
+
+import { ZERO } from 'appConstants';
+import { AccountDelegationType } from 'types';
+
+export const getAccountDelegationDetails = (
+  delegation: AccountDelegationType[]
+) => {
+  if (delegation && delegation.length > 0) {
+    const bNactive = delegation
+      .map(({ userActiveStake }) => userActiveStake)
+      .reduce((a, b) => new BigNumber(a).plus(b), new BigNumber(ZERO));
+    const bNclaimableRewards = delegation
+      .map(({ claimableRewards }) => claimableRewards ?? ZERO)
+      .reduce((a, b) => new BigNumber(a).plus(b), new BigNumber(ZERO));
+    const undelegatedAmounts = delegation
+      .map(
+        ({ userUndelegatedList }) =>
+          userUndelegatedList?.map(({ amount }) => amount) ?? []
+      )
+      .reduce((a, b) => a.concat(b), []);
+    const bNunstaked = undelegatedAmounts.reduce(
+      (a, b) => new BigNumber(a).plus(b),
+      new BigNumber(ZERO)
+    );
+    const bNunbondable = delegation
+      .map(({ userUnBondable }) => userUnBondable)
+      .reduce((a, b) => new BigNumber(a).plus(b), new BigNumber(ZERO));
+
+    const activePlusUnStaked = bNactive.plus(bNunstaked);
+    const bNlocked = activePlusUnStaked
+      .plus(bNclaimableRewards)
+      .plus(bNunbondable);
+
+    const show = bNlocked.isGreaterThan(0);
+
+    return {
+      active: bNactive,
+      unstaked: bNunstaked.plus(bNunbondable),
+      claimable: bNclaimableRewards,
+      locked: bNlocked,
+      show
+    };
+  }
+
+  return {
+    active: new BigNumber(ZERO),
+    unstaked: new BigNumber(ZERO),
+    claimable: new BigNumber(ZERO),
+    locked: new BigNumber(ZERO),
+    show: false
+  };
+};

--- a/src/helpers/getValue/getAccountLegacyDelegationDetails.ts
+++ b/src/helpers/getValue/getAccountLegacyDelegationDetails.ts
@@ -1,0 +1,53 @@
+import BigNumber from 'bignumber.js';
+
+import { ZERO } from 'appConstants';
+import { AccountDelegationLegacyType } from 'types';
+
+export const getAccountLegacyDelegationDetails = (
+  delegationLegacy: AccountDelegationLegacyType
+) => {
+  if (delegationLegacy) {
+    const bNactive = new BigNumber(delegationLegacy.userActiveStake ?? ZERO);
+    const bNuserWaitingStake = new BigNumber(
+      delegationLegacy.userWaitingStake ?? ZERO
+    );
+    const bNclaimableRewards = new BigNumber(
+      delegationLegacy.claimableRewards ?? ZERO
+    );
+    const bNunstakedStakeLegacy = new BigNumber(
+      delegationLegacy.userUnstakedStake ?? ZERO
+    );
+    const bNdeferredPaymentLegacy = new BigNumber(
+      delegationLegacy.userDeferredPaymentStake ?? ZERO
+    );
+    const bNwithdrawOnlyStakeLegacy = new BigNumber(
+      delegationLegacy.userWithdrawOnlyStake ?? ZERO
+    );
+
+    const bNunstaked = bNunstakedStakeLegacy.plus(bNdeferredPaymentLegacy);
+    const bNlocked = bNactive
+      .plus(bNuserWaitingStake)
+      .plus(bNclaimableRewards)
+      .plus(bNunstakedStakeLegacy)
+      .plus(bNdeferredPaymentLegacy)
+      .plus(bNwithdrawOnlyStakeLegacy);
+
+    const show = bNlocked.isGreaterThan(0);
+
+    return {
+      active: bNactive,
+      unstaked: bNunstaked,
+      claimable: bNclaimableRewards,
+      locked: bNlocked,
+      show
+    };
+  }
+
+  return {
+    active: new BigNumber(ZERO),
+    unstaked: new BigNumber(ZERO),
+    claimable: new BigNumber(ZERO),
+    locked: new BigNumber(ZERO),
+    show: false
+  };
+};

--- a/src/helpers/getValue/getAccountStakingDetails.ts
+++ b/src/helpers/getValue/getAccountStakingDetails.ts
@@ -1,0 +1,81 @@
+import BigNumber from 'bignumber.js';
+
+import {
+  getAccountDelegationDetails,
+  getAccountLegacyDelegationDetails,
+  getAccountValidatorStakeDetails
+} from 'helpers';
+import {
+  AccountDelegationType,
+  AccountDelegationLegacyType,
+  AccountStakeType
+} from 'types';
+
+export const getAccountStakingDetails = ({
+  stake,
+  delegation,
+  legacyDelegation
+}: {
+  stake: AccountStakeType;
+  delegation: AccountDelegationType[];
+  legacyDelegation: AccountDelegationLegacyType;
+}) => {
+  const {
+    active: activeDelegation,
+    claimable: claimableDelegation,
+    unstaked: unstakedDelegation,
+    locked: lockedDelegation,
+    show: showDelegation
+  } = getAccountDelegationDetails(delegation);
+
+  const {
+    active: activeLegacyDelegation,
+    claimable: claimableLegacyDelegation,
+    unstaked: unstakedLegacyDelegation,
+    locked: lockedLegacyDelegation,
+    show: showLegacyDelegation
+  } = getAccountLegacyDelegationDetails(legacyDelegation);
+
+  const {
+    active: activeValidatorStake,
+    unstaked: unstakedValidatorStake,
+    locked: lockedValidatorStake,
+    show: showValidatorStake
+  } = getAccountValidatorStakeDetails(stake);
+
+  const totalActiveStake = activeDelegation
+    .plus(activeLegacyDelegation)
+    .plus(activeValidatorStake);
+  const totalLocked = new BigNumber(lockedDelegation)
+    .plus(lockedLegacyDelegation)
+    .plus(lockedValidatorStake);
+  const totalClaimable = new BigNumber(claimableDelegation).plus(
+    claimableLegacyDelegation
+  );
+  const totalUnstaked = unstakedDelegation
+    .plus(unstakedLegacyDelegation)
+    .plus(unstakedValidatorStake);
+
+  const showStakingDetails =
+    showDelegation || showLegacyDelegation || showValidatorStake;
+
+  return {
+    showDelegation,
+    showLegacyDelegation,
+    showValidatorStake,
+    showStakingDetails,
+
+    activeValidatorStake: activeValidatorStake.toString(10),
+    activeDelegation: activeDelegation.toString(10),
+    activeLegacyDelegation: activeLegacyDelegation.toString(10),
+
+    lockedValidatorStake: lockedValidatorStake.toString(10),
+    lockedDelegation: lockedDelegation.toString(10),
+    lockedLegacyDelegation: lockedLegacyDelegation.toString(10),
+
+    totalActiveStake: totalActiveStake.toString(10),
+    totalLocked: totalLocked.toString(10),
+    totalClaimable: totalClaimable.toString(10),
+    totalUnstaked: totalUnstaked.toString(10)
+  };
+};

--- a/src/helpers/getValue/getAccountValidatorStakeDetails.ts
+++ b/src/helpers/getValue/getAccountValidatorStakeDetails.ts
@@ -1,0 +1,35 @@
+import BigNumber from 'bignumber.js';
+
+import { ZERO } from 'appConstants';
+import { AccountStakeType } from 'types';
+
+export const getAccountValidatorStakeDetails = (stake: AccountStakeType) => {
+  if (stake) {
+    const bNactive = new BigNumber(stake.totalStaked ?? ZERO);
+    const bNunstaked =
+      stake.unstakedTokens && stake.unstakedTokens.length > 0
+        ? stake.unstakedTokens
+            .map(({ amount }) => amount)
+            .reduce((a, b) => new BigNumber(a).plus(b), new BigNumber(ZERO))
+        : new BigNumber(ZERO);
+
+    const bNlocked = bNactive.plus(bNunstaked);
+    const show = bNlocked.isGreaterThan(0);
+
+    return {
+      active: bNactive,
+      unstaked: bNunstaked,
+      claimable: new BigNumber(ZERO),
+      locked: bNlocked,
+      show
+    };
+  }
+
+  return {
+    active: new BigNumber(ZERO),
+    unstaked: new BigNumber(ZERO),
+    claimable: new BigNumber(ZERO),
+    locked: new BigNumber(ZERO),
+    show: false
+  };
+};

--- a/src/helpers/getValue/index.ts
+++ b/src/helpers/getValue/index.ts
@@ -1,3 +1,7 @@
+export * from './getAccountDelegationDetails';
+export * from './getAccountLegacyDelegationDetails';
+export * from './getAccountStakingDetails';
+export * from './getAccountValidatorStakeDetails';
 export * from './getColors';
 export * from './getDisplayReceiver';
 export * from './getNftText';

--- a/src/hooks/fetch/useFetchAccountStakingDetails.ts
+++ b/src/hooks/fetch/useFetchAccountStakingDetails.ts
@@ -1,10 +1,15 @@
-import BigNumber from 'bignumber.js';
 import { useDispatch } from 'react-redux';
 
 import { LEGACY_DELEGATION_NODES_IDENTITY } from 'appConstants';
+import { getAccountStakingDetails } from 'helpers';
 import { useAdapter } from 'hooks';
 import { setAccountStaking } from 'redux/slices';
-import { IdentityType, ProviderType, AccountDelegationType } from 'types';
+import {
+  IdentityType,
+  ProviderType,
+  AccountDelegationType,
+  ApiAdapterResponseType
+} from 'types';
 
 let currentRequest: any = null;
 
@@ -15,7 +20,7 @@ export const useFetchAccountStakingDetails = () => {
     getAccountDelegation,
     getAccountStake,
     getProviders,
-    getIdentities
+    getIdentity
   } = useAdapter();
 
   const getAccountStakingDetailsOnce = ({ address }: { address: string }) => {
@@ -50,254 +55,83 @@ export const useFetchAccountStakingDetails = () => {
     const [delegationData, stakeData, delegationLegacyData] =
       await getAccountStakingDetailsOnce({ address });
 
-    let delegationLegacyIdentity: IdentityType | undefined = undefined;
-    const delegationProviders: ProviderType[] = [];
-    let bNtotalStaked = new BigNumber(0);
-    let bNtotalDelegation = new BigNumber(0);
-    let bNtotalLegacyDelegation = new BigNumber(0);
-    let bNtotalLocked = new BigNumber(0);
-    let bNtotalClaimable = new BigNumber(0);
-    let bNtotalActiveStake = new BigNumber(0);
-    let bNtotalUnstakedValue = new BigNumber(0);
-
-    const delegationFetched = delegationData.success ? delegationData.data : {};
-    const stakeFetched = stakeData.success ? stakeData.data : {};
-    const delegationLegacyFetched = delegationLegacyData.success
-      ? delegationLegacyData.data
-      : {};
+    const delegationFetched = delegationData.success && delegationData.data;
+    const stakeFetched = stakeData.success && stakeData.data;
+    const delegationLegacyFetched =
+      delegationLegacyData.success && delegationLegacyData.data;
 
     const delegation: AccountDelegationType[] = delegationFetched
       ? delegationData.data
       : [];
     const stake = stakeFetched ? stakeData.data : {};
-    const delegationLegacy = delegationLegacyFetched
+    const legacyDelegation = delegationLegacyFetched
       ? delegationLegacyData.data
       : {};
 
-    if (stake) {
-      bNtotalStaked = new BigNumber(stake.totalStaked ? stake.totalStaked : 0);
-    }
-    if (delegationLegacy) {
-      const bNuserActiveStake = new BigNumber(delegationLegacy.userActiveStake);
-      const bNuserWaitingStake = new BigNumber(
-        delegationLegacy.userWaitingStake
-      );
-      const bNClaimableRewardsLegacy = new BigNumber(
-        delegationLegacy.claimableRewards
-      );
+    const stakingDetails = getAccountStakingDetails({
+      delegation,
+      stake,
+      legacyDelegation
+    });
+    const { showDelegation, showLegacyDelegation } = stakingDetails;
 
-      bNtotalClaimable = bNtotalClaimable.plus(bNClaimableRewardsLegacy);
-      bNtotalLegacyDelegation = new BigNumber(
-        bNuserActiveStake
-          .plus(bNuserWaitingStake)
-          .plus(bNClaimableRewardsLegacy)
-      );
-
-      if (delegationLegacy.userUnstakedStake) {
-        const bNunstakedStakeLegacy = new BigNumber(
-          delegationLegacy.userUnstakedStake
-        );
-        bNtotalUnstakedValue = bNtotalUnstakedValue.plus(bNunstakedStakeLegacy);
-      }
-      if (delegationLegacy.userDeferredPaymentStake) {
-        const bNdeferredPaymentLegacy = new BigNumber(
-          delegationLegacy.userDeferredPaymentStake
-        );
-        bNtotalUnstakedValue = bNtotalUnstakedValue.plus(
-          bNdeferredPaymentLegacy
-        );
-      }
-    }
-
-    if (delegation && delegation.length > 0) {
-      const bNtotalUserActiveStake = delegation
-        .map(({ userActiveStake }) => userActiveStake)
-        .reduce((a, b) => new BigNumber(a).plus(b), new BigNumber('0'));
-      const bNtotalClaimableRewards = delegation
-        .map(({ claimableRewards }) => claimableRewards || '0')
-        .reduce((a, b) => new BigNumber(a).plus(b), new BigNumber('0'));
-      const undelegatedAmounts = delegation
-        .map(
-          ({ userUndelegatedList }) =>
-            userUndelegatedList?.map(({ amount }) => amount) ?? []
-        )
-        .reduce((a, b) => a.concat(b), []);
-      const bNtotalUserUnStakedValue = undelegatedAmounts.reduce(
-        (a, b) => new BigNumber(a).plus(b),
-        new BigNumber('0')
-      );
-      const activePlusUnStaked = bNtotalUserActiveStake.plus(
-        bNtotalUserUnStakedValue
-      );
-      bNtotalActiveStake = bNtotalUserActiveStake;
-      bNtotalUnstakedValue = bNtotalUnstakedValue.plus(
-        bNtotalUserUnStakedValue
-      );
-      bNtotalDelegation = bNtotalClaimableRewards.plus(activePlusUnStaked);
-      bNtotalClaimable = bNtotalClaimable.plus(bNtotalClaimableRewards);
-    }
-    if (stake && delegation && delegationLegacy) {
-      bNtotalLocked = bNtotalStaked
-        .plus(bNtotalLegacyDelegation)
-        .plus(bNtotalDelegation);
-    }
-
-    const visibleDelegation =
-      delegation?.filter(
-        (delegation) =>
-          delegation.userActiveStake !== '0' ||
-          delegation.claimableRewards !== '0' ||
-          (delegation.userUndelegatedList &&
-            delegation.userUndelegatedList.length > 0)
-      ) ?? [];
-    const showDelegation = visibleDelegation.length > 0;
-
-    const showDelegationLegacy =
-      delegationLegacy &&
-      (delegationLegacy.claimableRewards !== '0' ||
-        delegationLegacy.userWaitingStake !== '0' ||
-        delegationLegacy.userActiveStake !== '0' ||
-        delegationLegacy.userUnstakedStake !== '0' ||
-        delegationLegacy.userDeferredPaymentStake !== '0');
-
-    const showStake = Boolean(
-      stake &&
-        (stake?.totalStaked !== '0' ||
-          (stake?.unstakedTokens && stake.unstakedTokens.length > 0))
-    );
-
-    //const updatedContracts = contracts ? contracts.join(',') : undefined;
-    const fields = [
-      'identity',
-      'provider',
-      'stake',
-      'numNodes',
-      'apr',
-      'serviceFee',
-      'delegationCap'
-    ].join(',');
-    const contracts = visibleDelegation
-      .map((delegation) => delegation?.contract)
-      .join(',');
-
-    const stakingDataReady = Boolean(
+    const accountStakingFetched = Boolean(
       stakeFetched && delegationFetched && delegationLegacyFetched
     );
     const stakingData = {
       address,
-      stakingDataReady,
-      delegation,
-      showDelegation,
       stake,
-      showStake,
-      delegationLegacy,
-      showDelegationLegacy,
-      totalStaked: bNtotalStaked.toString(),
-      totalDelegation: bNtotalDelegation.toString(),
-      totalLegacyDelegation: bNtotalLegacyDelegation.toString(),
-      totalLocked: bNtotalLocked.toString(),
-      totalClaimable: bNtotalClaimable.toString(),
-      totalActiveStake: bNtotalActiveStake.toString(),
-      totalUnstakedValue: bNtotalUnstakedValue.toString()
+      legacyDelegation,
+      delegation,
+      ...stakingDetails
     };
 
-    if (showDelegation || showDelegationLegacy) {
-      getProviders({
-        fields,
-        ...(contracts ? { providers: contracts } : {})
-      }).then((providersData) => {
-        if (providersData.success) {
-          const newProvidersData: ProviderType[] = providersData.data;
+    if (showDelegation || showLegacyDelegation) {
+      const fields = [
+        'identity',
+        'provider',
+        'stake',
+        'numNodes',
+        'apr',
+        'serviceFee',
+        'delegationCap'
+      ].join(',');
+      const providers = showDelegation
+        ? delegation.map((delegation) => delegation?.contract).join(',')
+        : '';
 
-          const providerIdentitiesList = newProvidersData
-            .filter((item) => item.identity)
-            .map((item) => item.identity);
-
-          if (
-            showDelegationLegacy &&
-            !providerIdentitiesList.includes(LEGACY_DELEGATION_NODES_IDENTITY)
-          ) {
-            providerIdentitiesList.push(LEGACY_DELEGATION_NODES_IDENTITY);
-          }
-
-          const identities = providerIdentitiesList.join(',');
-
-          if (identities) {
-            getIdentities({ identities }).then((identitiesData) => {
-              if (identitiesData.success) {
-                newProvidersData.forEach((provider) => {
-                  if (provider.identity) {
-                    const identityDetails = identitiesData.data.find(
-                      (identity: IdentityType) =>
-                        identity.identity === provider.identity
-                    );
-
-                    const multiversXNodes = identitiesData.data.filter(
-                      (identity: IdentityType) => {
-                        return (
-                          identity.identity === LEGACY_DELEGATION_NODES_IDENTITY
-                        );
-                      }
-                    );
-                    if (multiversXNodes.length > 0) {
-                      delegationLegacyIdentity = multiversXNodes[0];
-                    }
-
-                    if (identityDetails) {
-                      provider.identityDetails = identityDetails;
-                    }
-                  }
-                });
-
-                dispatch(
-                  setAccountStaking({
-                    ...stakingData,
-                    accountStakingFetched: stakingDataReady,
-                    providerDataReady: true,
-                    delegationProviders: newProvidersData,
-                    delegationLegacyIdentity
-                  })
-                );
-              }
-
-              dispatch(
-                setAccountStaking({
-                  ...stakingData,
-                  accountStakingFetched: stakingDataReady,
-                  providerDataReady: true,
-                  delegationProviders: newProvidersData,
-                  delegationLegacyIdentity
-                })
-              );
-            });
-          } else {
-            dispatch(
-              setAccountStaking({
-                ...stakingData,
-                accountStakingFetched: stakingDataReady,
-                providerDataReady: true,
-                delegationProviders: providersData.data,
-                delegationLegacyIdentity
-              })
-            );
-          }
-        } else {
-          dispatch(
-            setAccountStaking({
-              ...stakingData,
-              accountStakingFetched: stakingDataReady,
-              providerDataReady: providersData.success,
-              delegationProviders,
-              delegationLegacyIdentity
+      const [providersData, legacyIdentityData] = await Promise.all([
+        providers
+          ? getProviders({
+              fields,
+              providers,
+              withIdentityInfo: true
             })
-          );
-        }
-      });
-    } else {
+          : Promise.resolve({ success: true } as ApiAdapterResponseType),
+
+        showLegacyDelegation
+          ? getIdentity(LEGACY_DELEGATION_NODES_IDENTITY)
+          : Promise.resolve({ success: true } as ApiAdapterResponseType)
+      ]);
+
       dispatch(
         setAccountStaking({
           ...stakingData,
-          accountStakingFetched: stakingDataReady,
+          accountStakingFetched,
+          providerDataReady:
+            providersData.success && legacyIdentityData.success,
+          delegationProviders: providersData?.data,
+          delegationLegacyIdentity: legacyIdentityData?.data
+        })
+      );
+    } else {
+      const delegationLegacyIdentity: IdentityType | undefined = undefined;
+      const delegationProviders: ProviderType[] = [];
+
+      dispatch(
+        setAccountStaking({
+          ...stakingData,
+          accountStakingFetched,
           providerDataReady: true,
           delegationProviders,
           delegationLegacyIdentity

--- a/src/layouts/AccountLayout/AccountDetailsCard/components/AccountUsdValueCardItem.tsx
+++ b/src/layouts/AccountLayout/AccountDetailsCard/components/AccountUsdValueCardItem.tsx
@@ -25,7 +25,7 @@ export const AccountUsdValueCardItem = ({
   const { accountExtra, isFetched: isAccountExtraFetched } =
     useSelector(accountExtraSelector);
   const {
-    stakingDataReady,
+    accountStakingFetched,
     totalLocked,
     address: lockedAddress
   } = useSelector(accountStakingSelector);
@@ -34,8 +34,8 @@ export const AccountUsdValueCardItem = ({
   const { tokenBalance, address: extraAddress } = accountExtra;
 
   let totalWorth = balance ? new BigNumber(balance) : new BigNumber(0);
-  if (stakingDataReady) {
-    totalWorth = totalWorth.plus(new BigNumber(totalLocked));
+  if (accountStakingFetched) {
+    totalWorth = totalWorth.plus(totalLocked);
   }
   const formattedTotalWorth = formatAmount({
     input: totalWorth.toString(10),
@@ -55,7 +55,7 @@ export const AccountUsdValueCardItem = ({
 
   const isDataReady =
     isAccountExtraFetched &&
-    stakingDataReady &&
+    accountStakingFetched &&
     isEconomicsFetched &&
     isCorrectData;
 
@@ -94,7 +94,7 @@ export const AccountUsdValueCardItem = ({
                 )
               },
               {
-                label: 'Stake',
+                label: 'Stake (Locked)',
                 value: (
                   <FormatUSD
                     value={new BigNumber(totalLocked ?? 0).toString(10)}

--- a/src/layouts/AccountLayout/AccountDetailsCard/components/LockedAmountCardItem.tsx
+++ b/src/layouts/AccountLayout/AccountDetailsCard/components/LockedAmountCardItem.tsx
@@ -14,60 +14,54 @@ export const LockedAmountCardItem = ({
 }) => {
   const {
     address: lockedAddress,
-    stakingDataReady,
-    totalStaked,
-    totalLegacyDelegation,
+    accountStakingFetched,
+
+    activeValidatorStake,
+    activeDelegation,
+    activeLegacyDelegation,
+
     totalLocked,
     totalClaimable,
-    totalActiveStake,
-    totalUnstakedValue
+    totalUnstaked
   } = useSelector(accountStakingSelector);
   const { account } = useSelector(accountSelector);
-
-  const bNtotalStaked = new BigNumber(totalStaked);
-  const bNtotalActiveStake = new BigNumber(totalActiveStake);
-  const bNtotalLegacyDelegation = new BigNumber(totalLegacyDelegation);
-  const bNtotalLocked = new BigNumber(totalLocked);
-  const bNtotalClaimable = new BigNumber(totalClaimable);
-  const bNUnstaked = new BigNumber(totalUnstakedValue);
+  const hasUnstaked = new BigNumber(totalUnstaked).isGreaterThan(0);
 
   const lockedDetails = [
     {
-      label: 'Stake',
-      value: <FormatAmount value={bNtotalStaked.toString(10)} />
+      label: 'Stake (Validation)',
+      value: <FormatAmount value={activeValidatorStake} />
     },
     {
       label: 'Delegation',
-      value: <FormatAmount value={bNtotalActiveStake.toString(10)} />
+      value: <FormatAmount value={activeDelegation} />
     },
     {
       label: 'Legacy Delegation',
-      value: <FormatAmount value={bNtotalLegacyDelegation.toString(10)} />
+      value: <FormatAmount value={activeLegacyDelegation} />
     },
     {
       label: 'Claimable Rewards',
-      value: <FormatAmount value={bNtotalClaimable.toString(10)} />
+      value: <FormatAmount value={totalClaimable} />
     }
   ];
 
-  if (bNUnstaked.isGreaterThan(0)) {
+  if (hasUnstaked) {
     lockedDetails.push({
       label: 'Unstaked',
-      value: <FormatAmount value={bNUnstaked.toString(10)} />
+      value: <FormatAmount value={totalUnstaked} />
     });
   }
 
   const isDataReady =
-    stakingDataReady && account.address && account.address === lockedAddress;
+    accountStakingFetched &&
+    account.address &&
+    account.address === lockedAddress;
 
   return (
     <CardItem className={classNames(cardItemClass)} title='Stake' icon={faLock}>
       <div className='d-flex align-items-center'>
-        {isDataReady ? (
-          <FormatAmount value={bNtotalLocked.toString(10)} />
-        ) : (
-          ELLIPSIS
-        )}
+        {isDataReady ? <FormatAmount value={totalLocked} /> : ELLIPSIS}
         {isDataReady && <LockedAmountTooltip lockedDetails={lockedDetails} />}
       </div>
     </CardItem>

--- a/src/pages/AccountDetails/AccountStaking/AccountStaking.tsx
+++ b/src/pages/AccountDetails/AccountStaking/AccountStaking.tsx
@@ -22,33 +22,28 @@ export const AccountStaking = () => {
   const stakingDetails = useSelector(accountStakingSelector);
   const {
     address: stateAddress,
-    providerDataReady,
-    stakingDataReady,
-    delegation,
-    delegationProviders,
-    stake,
-    delegationLegacy,
-    delegationLegacyIdentity,
+
     showDelegation,
-    showDelegationLegacy,
-    showStake
+    showLegacyDelegation,
+    showValidatorStake,
+    showStakingDetails,
+
+    delegation,
+    stake,
+    legacyDelegation,
+
+    providerDataReady,
+    delegationProviders,
+    delegationLegacyIdentity,
+
+    accountStakingFetched
   } = stakingDetails;
 
-  const displayDelegation = delegation
-    ? delegation.filter(
-        (delegation) =>
-          delegation.userActiveStake !== '0' ||
-          delegation.claimableRewards !== '0' ||
-          (delegation.userUndelegatedList &&
-            delegation.userUndelegatedList?.length > 0)
-      )
-    : [];
-
   const needsData = address && address !== stateAddress;
-  const hasStaking = showDelegation || showDelegationLegacy || showStake;
+
   const isReady =
     providerDataReady &&
-    stakingDataReady &&
+    accountStakingFetched &&
     ((needsData && dataReady) || !needsData);
 
   useEffect(() => {
@@ -75,27 +70,24 @@ export const AccountStaking = () => {
       <div className='account-staking card-body'>
         {isReady ? (
           <div className='row'>
-            {hasStaking ? (
+            {accountStakingFetched && showStakingDetails ? (
               <>
                 <div className='col-lg-5 ps-lg-0 d-flex flex-column'>
                   <div className='px-spacer py-3 staking-chart-title'>
                     Staking Chart
                   </div>
                   <div className='staking-chart-holder'>
-                    <DonutChart
-                      stakingDetails={stakingDetails}
-                      providers={delegationProviders}
-                    />
+                    <DonutChart />
                   </div>
                 </div>
                 <div className='col-lg-7 pe-lg-0 order-lg-first'>
-                  {displayDelegation.length > 0 && (
+                  {showDelegation && delegation && delegation.length > 0 && (
                     <div className='account-delegation stake-container'>
                       <div className='px-spacer py-3 delegation-title'>
                         Staking List
                       </div>
                       <div className='d-flex flex-column staking-list'>
-                        {displayDelegation.map((delegation, i) => {
+                        {delegation.map((delegation, i) => {
                           const provider = delegationProviders?.find(
                             ({ provider }) => delegation.contract === provider
                           );
@@ -110,19 +102,19 @@ export const AccountStaking = () => {
                       </div>
                     </div>
                   )}
-                  {delegationLegacy && showDelegationLegacy && (
+                  {showLegacyDelegation && legacyDelegation && (
                     <div className='account-legacy-delegation stake-container'>
                       <div className='px-spacer py-3 delegation-title'>
                         Legacy Delegation
                       </div>
 
                       <AccountLegacyDelegation
-                        delegationLegacy={delegationLegacy}
+                        legacyDelegation={legacyDelegation}
                         identity={delegationLegacyIdentity}
                       />
                     </div>
                   )}
-                  {stake && showStake && (
+                  {showValidatorStake && stake && (
                     <div className='account-stake stake-container'>
                       <div className='px-spacer py-3 delegation-title'>
                         Stake{' '}

--- a/src/pages/AccountDetails/AccountStaking/components/AccountDelegation/AccountDelegation.tsx
+++ b/src/pages/AccountDetails/AccountStaking/components/AccountDelegation/AccountDelegation.tsx
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { useSelector } from 'react-redux';
 
+import { ZERO } from 'appConstants';
 import { FormatAmount } from 'components';
 import { activeNetworkSelector } from 'redux/selectors';
 import { AccountDelegationType, ProviderType } from 'types';
@@ -18,25 +19,22 @@ export const AccountDelegation = ({
   const { egldLabel } = useSelector(activeNetworkSelector);
 
   const { userActiveStake } = delegation;
-  const claimableRewards = delegation.claimableRewards || '0';
+  const claimableRewards = delegation.claimableRewards || ZERO;
 
   const undelegatedAmounts =
     delegation?.userUndelegatedList && delegation.userUndelegatedList.length > 0
       ? delegation.userUndelegatedList.map(({ amount }) => amount)
       : [];
-  const bNtotalUserUnStakedValue =
-    undelegatedAmounts.length > 0
-      ? undelegatedAmounts.reduce(
-          (a, b) => new BigNumber(a).plus(b),
-          new BigNumber('0')
-        )
-      : null;
+  const bNtotalUserUnStakedValue = undelegatedAmounts.reduce(
+    (a, b) => new BigNumber(a).plus(b),
+    new BigNumber(ZERO)
+  );
 
   return (
     <div className='delegation-row d-flex flex-wrap align-items-center justify-content-between p-3 px-md-4'>
       <ProviderDetails provider={provider} />
 
-      {userActiveStake !== '0' && (
+      {userActiveStake !== ZERO && (
         <DetailsBlock>
           <strong>
             <FormatAmount value={userActiveStake} />
@@ -45,7 +43,7 @@ export const AccountDelegation = ({
         </DetailsBlock>
       )}
 
-      {bNtotalUserUnStakedValue && (
+      {bNtotalUserUnStakedValue.isGreaterThan(ZERO) && (
         <DetailsBlock>
           <strong>
             <FormatAmount value={bNtotalUserUnStakedValue.toString(10)} />

--- a/src/pages/AccountDetails/AccountStaking/components/AccountLegacyDelegation/AccountLegacyDelegation.tsx
+++ b/src/pages/AccountDetails/AccountStaking/components/AccountLegacyDelegation/AccountLegacyDelegation.tsx
@@ -13,10 +13,10 @@ import { AccountDelegationLegacyType, IdentityType } from 'types';
 import { DetailsBlock } from '../DetailsBlock';
 
 export const AccountLegacyDelegation = ({
-  delegationLegacy,
+  legacyDelegation,
   identity
 }: {
-  delegationLegacy: AccountDelegationLegacyType;
+  legacyDelegation: AccountDelegationLegacyType;
   identity?: IdentityType;
 }) => {
   const {
@@ -31,7 +31,7 @@ export const AccountLegacyDelegation = ({
     userUnstakedStake,
     userWaitingStake,
     userDeferredPaymentStake
-  } = delegationLegacy;
+  } = legacyDelegation;
 
   const [legacyDelegationApr, setLegacyDelegationApr] =
     useState<string>(ELLIPSIS);

--- a/src/pages/AccountDetails/AccountStaking/components/DonutChart/DonutChart.tsx
+++ b/src/pages/AccountDetails/AccountStaking/components/DonutChart/DonutChart.tsx
@@ -1,25 +1,16 @@
-import BigNumber from 'bignumber.js';
+import { useSelector } from 'react-redux';
 
 import { FormatAmount, FormatUSD, Chart } from 'components';
 import { ChartConfigType } from 'components/Chart/helpers/types';
 import { DECIMALS } from 'config';
-import { ProviderType } from 'types';
-import { AccountStakingSliceType } from 'types/account.types';
+import { accountStakingSelector } from 'redux/selectors';
 
 import { prepareChartData } from './helpers/prepareChartData';
 
-export const DonutChart = ({
-  stakingDetails,
-  providers
-}: {
-  stakingDetails: AccountStakingSliceType;
-  providers?: ProviderType[];
-}) => {
-  const chartData = providers
-    ? prepareChartData({ stakingDetails, providers })
-    : [];
-  const { totalLocked } = stakingDetails;
-  const bNtotalLocked = new BigNumber(totalLocked);
+export const DonutChart = () => {
+  const stakingDetails = useSelector(accountStakingSelector);
+  const chartData = prepareChartData({ stakingDetails });
+  const { totalLocked, showStakingDetails } = stakingDetails;
 
   const config: ChartConfigType[] = [
     {
@@ -29,25 +20,20 @@ export const DonutChart = ({
     }
   ];
 
-  const hasNoActiveStake = bNtotalLocked.isEqualTo(0);
-
   return (
     <>
       <div className='staking-details-center'>
         <h5 className='mb-1'>
-          {hasNoActiveStake ? 'No staking' : 'Total Staked'}
+          {showStakingDetails ? 'Total Locked' : 'No staking'}
         </h5>
-        {!hasNoActiveStake && (
+        {showStakingDetails && (
           <>
             <h6 className='mb-1'>
-              <FormatAmount
-                value={bNtotalLocked.toString(10)}
-                showUsdValue={false}
-              />
+              <FormatAmount value={totalLocked} showUsdValue={false} />
             </h6>
             <div className='text-neutral-400 small mb-0'>
               <FormatUSD
-                value={bNtotalLocked.toString(10)}
+                value={totalLocked}
                 decimals={DECIMALS}
                 showPrefix={false}
               />

--- a/src/pages/AccountDetails/AccountStaking/components/ProviderDetails/ProviderDetails.tsx
+++ b/src/pages/AccountDetails/AccountStaking/components/ProviderDetails/ProviderDetails.tsx
@@ -27,7 +27,7 @@ export const ProviderDetails = ({ provider }: { provider: ProviderType }) => {
   }
 
   const websiteLink = getValidLink({
-    link: provider?.identityDetails?.website
+    link: provider?.identityInfo?.website
   });
 
   return provider ? (
@@ -35,8 +35,8 @@ export const ProviderDetails = ({ provider }: { provider: ProviderType }) => {
       <div className='d-flex flex-row align-items-center'>
         <ImageWithFallback
           className='provider-image rounded-circle d-flex me-3 '
-          src={provider?.identityDetails?.avatar ?? PLACEHOLDER_IMAGE_PATH}
-          alt={provider?.identityDetails?.name ?? provider.provider}
+          src={provider?.identityInfo?.avatar ?? PLACEHOLDER_IMAGE_PATH}
+          alt={provider?.identityInfo?.name ?? provider.provider}
           height='42'
         />
         <div className='d-flex flex-column w-100'>
@@ -45,9 +45,9 @@ export const ProviderDetails = ({ provider }: { provider: ProviderType }) => {
               to={urlBuilder.providerDetails(provider.provider)}
               className='provider-title'
             >
-              {provider?.identityDetails?.name ? (
+              {provider?.identityInfo?.name ? (
                 <div className='text-truncate'>
-                  {provider.identityDetails.name}
+                  {provider.identityInfo.name}
                 </div>
               ) : (
                 <Trim text={provider.provider} />

--- a/src/redux/slices/accountStaking.ts
+++ b/src/redux/slices/accountStaking.ts
@@ -1,21 +1,30 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { ELLIPSIS } from 'appConstants';
 import { AccountStakingSliceType } from 'types/account.types';
 
 export const getInitialAccountStakingState = (): AccountStakingSliceType => {
   return {
     address: '',
+
     showDelegation: false,
-    showDelegationLegacy: false,
-    showStake: false,
-    totalStaked: '0',
-    totalDelegation: '0',
-    totalLegacyDelegation: '0',
-    totalLocked: '0',
-    totalClaimable: '0',
-    totalActiveStake: '0',
-    totalUnstakedValue: '0',
+    showLegacyDelegation: false,
+    showValidatorStake: false,
+    showStakingDetails: false,
+
+    activeValidatorStake: ELLIPSIS,
+    activeDelegation: ELLIPSIS,
+    activeLegacyDelegation: ELLIPSIS,
+
+    lockedValidatorStake: ELLIPSIS,
+    lockedDelegation: ELLIPSIS,
+    lockedLegacyDelegation: ELLIPSIS,
+
+    totalActiveStake: ELLIPSIS,
+    totalLocked: ELLIPSIS,
+    totalClaimable: ELLIPSIS,
+    totalUnstaked: ELLIPSIS,
+
     providerDataReady: undefined,
-    stakingDataReady: undefined,
     delegationProviders: [],
     delegationLegacyIdentity: undefined,
 
@@ -32,21 +41,30 @@ export const accountStakingSlice = createSlice({
       action: PayloadAction<AccountStakingSliceType>
     ) => {
       state.address = action.payload.address;
-      state.totalStaked = action.payload.totalStaked;
-      state.totalDelegation = action.payload.totalDelegation;
-      state.totalLegacyDelegation = action.payload.totalLegacyDelegation;
+
+      state.showDelegation = action.payload.showDelegation;
+      state.showLegacyDelegation = action.payload.showLegacyDelegation;
+      state.showValidatorStake = action.payload.showValidatorStake;
+      state.showStakingDetails = action.payload.showStakingDetails;
+
+      state.activeValidatorStake = action.payload.activeValidatorStake;
+      state.activeDelegation = action.payload.activeDelegation;
+      state.activeLegacyDelegation = action.payload.activeLegacyDelegation;
+
+      state.lockedValidatorStake = action.payload.lockedValidatorStake;
+      state.lockedDelegation = action.payload.lockedDelegation;
+      state.lockedLegacyDelegation = action.payload.lockedLegacyDelegation;
+
+      state.totalActiveStake = action.payload.totalActiveStake;
       state.totalLocked = action.payload.totalLocked;
       state.totalClaimable = action.payload.totalClaimable;
-      state.totalActiveStake = action.payload.totalActiveStake;
-      state.totalUnstakedValue = action.payload.totalUnstakedValue;
+      state.totalUnstaked = action.payload.totalUnstaked;
+
       state.stake = action.payload.stake;
-      state.showStake = action.payload.showStake;
-      state.delegationLegacy = action.payload.delegationLegacy;
-      state.showDelegationLegacy = action.payload.showDelegationLegacy;
+      state.legacyDelegation = action.payload.legacyDelegation;
       state.delegation = action.payload.delegation;
-      state.showDelegation = action.payload.showDelegation;
+
       state.providerDataReady = action.payload.providerDataReady;
-      state.stakingDataReady = action.payload.stakingDataReady;
       state.delegationProviders = action.payload.delegationProviders;
       state.delegationLegacyIdentity = action.payload.delegationLegacyIdentity;
 

--- a/src/types/account.types.ts
+++ b/src/types/account.types.ts
@@ -45,26 +45,37 @@ export interface AccountSliceType extends SliceType {
 }
 
 export interface AccountStakingSliceType {
-  accountStakingFetched: boolean;
-
   address: string;
-  totalStaked: string;
-  totalDelegation: string;
-  totalLegacyDelegation: string;
+
+  showDelegation: boolean;
+  showLegacyDelegation: boolean;
+  showValidatorStake: boolean;
+  showStakingDetails: boolean;
+
+  activeValidatorStake: string;
+  activeDelegation: string;
+  activeLegacyDelegation: string;
+
+  lockedValidatorStake: string;
+  lockedDelegation: string;
+  lockedLegacyDelegation: string;
+
+  totalActiveStake: string;
   totalLocked: string;
   totalClaimable: string;
-  totalActiveStake: string;
-  totalUnstakedValue: string;
+  totalUnstaked: string;
+
+  // details
   stake?: AccountStakeType;
-  showStake: boolean;
-  delegationLegacy?: AccountDelegationLegacyType;
-  showDelegationLegacy: boolean;
+  legacyDelegation?: AccountDelegationLegacyType;
   delegation?: AccountDelegationType[];
-  showDelegation: boolean;
+
+  // provider details
   providerDataReady: undefined | boolean;
-  stakingDataReady: undefined | boolean;
   delegationProviders: ProviderType[];
   delegationLegacyIdentity: IdentityType | undefined;
+
+  accountStakingFetched: boolean;
 }
 
 export interface AccountExtraSliceType extends SliceType {


### PR DESCRIPTION
## Proposed Changes

- Refactor account Staking display
- Move delegation / legacyDelegation / validatorStake processing in separate files
- Simplify provider fetching, use withIdentityInfo flag
- Fetch providers/legacy delegation identity details only if needed
- Avoid throwing errors on formatAmount, display '...' and log the error
