### PR TITLE
Fix token holders fetch param

### DIFF
--- a/src/pages/TokenDetails/TokenAccounts.tsx
+++ b/src/pages/TokenDetails/TokenAccounts.tsx
@@ -31,8 +31,8 @@ export const TokenDetailsAccounts = () => {
 
   const fetchAccounts = () => {
     Promise.all([
-      getTokenAccounts({ tokenId: identifier, page, size }),
-      getTokenAccountsCount({ tokenId: identifier })
+      getTokenAccounts({ token: identifier, page, size }),
+      getTokenAccountsCount({ token: identifier })
     ]).then(([tokenAccountsData, tokenAccountsCountData]) => {
       if (tokenAccountsData.success && tokenAccountsCountData.success) {
         setAccounts(tokenAccountsData.data);


### PR DESCRIPTION
### Issue/Feature

The token holders list was broken due to a parameter rename in d94391e0583b050c2f9e319ad6154450742e62e6.
This PR fixes it by using the correct parameter when fetching the accounts list and total count.

### Contains breaking changes

- [x] No
- [ ] Yes

### Testing

- [x] User testing
- [ ] Unit tests
