### PR TITLE
Testnet Supernova

### DIFF
--- a/src/config/config.testnet.ts
+++ b/src/config/config.testnet.ts
@@ -17,7 +17,8 @@ export const networks: NetworkType[] = [
     explorerAddress: 'https://testnet-explorer.multiversx.com',
     nftExplorerAddress: 'https://testnet.xspotlight.com',
     apiAddress: 'https://testnet-api.multiversx.com',
-    updatesWebsocketUrl: 'https://testnet-socket-api.multiversx.com'
+    updatesWebsocketUrl: 'https://testnet-socket-api.multiversx.com',
+    refreshRate: 600
   },
 
   // Saved Custom Network Configs


### PR DESCRIPTION
### Issue/Feature

- set initial refreshRate on testnet to 600ms ( avoid unsynced animations on load )

### Contains breaking changes

- [x] No
- [ ] Yes

### Testing

- [x] User tesing
- [ ] Unit tests
