### PR TITLE
Supernova: set devnet refreshRate to 600ms

### DIFF
--- a/src/config/config.devnet.ts
+++ b/src/config/config.devnet.ts
@@ -17,7 +17,8 @@ export const networks: NetworkType[] = [
     explorerAddress: 'https://devnet-explorer.multiversx.com',
     nftExplorerAddress: 'https://devnet.xspotlight.com',
     apiAddress: 'https://devnet-api.multiversx.com',
-    updatesWebsocketUrl: 'https://devnet-socket-api.multiversx.com'
+    updatesWebsocketUrl: 'https://devnet-socket-api.multiversx.com',
+    refreshRate: 600
   },
 
   // Saved Custom Network Configs

--- a/src/config/config.multiple.ts
+++ b/src/config/config.multiple.ts
@@ -21,7 +21,8 @@ export const networks: NetworkType[] = [
     explorerAddress: 'https://testnet-explorer.multiversx.com/',
     nftExplorerAddress: 'https://testnet.xspotlight.com',
     apiAddress: 'https://testnet-api.multiversx.com',
-    updatesWebsocketUrl: 'https://testnet-socket-api.multiversx.com'
+    updatesWebsocketUrl: 'https://testnet-socket-api.multiversx.com',
+    refreshRate: 600
   },
   {
     id: 'devnet',
@@ -34,7 +35,8 @@ export const networks: NetworkType[] = [
     explorerAddress: 'https://devnet-explorer.multiversx.com',
     nftExplorerAddress: 'https://devnet.xspotlight.com',
     apiAddress: 'https://devnet-api.multiversx.com',
-    updatesWebsocketUrl: 'https://devnet-socket-api.multiversx.com'
+    updatesWebsocketUrl: 'https://devnet-socket-api.multiversx.com',
+    refreshRate: 600
   },
 
   // Internal Testnets


### PR DESCRIPTION
### Issue/Feature

- Supernova: set `devnet` refreshRate to 600ms

### Contains breaking changes

- [x] No
- [ ] Yes

### Testing

- [x] User tesing
- [ ] Unit tests
